### PR TITLE
feat(load): add load step to save curated data

### DIFF
--- a/.github/workflow/monthly_etl.yml
+++ b/.github/workflow/monthly_etl.yml
@@ -1,0 +1,33 @@
+name: Monthly ETL Pipeline
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Runs at 05:00 UTC on the 1st day of every month
+    # This is equivalent to 23:00  UTC-6 on the last day of the month.
+    - cron: '0 5 1 * *'
+
+jobs:
+  run-etl-pipeline:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Run ETL Script
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME }}
+          BASE_URL: ${{ secrets.BASE_URL }}
+          POS_API_KEY: ${{ secrets.POS_API_KEY }}
+        run: python main.py --step all

--- a/etl/load.py
+++ b/etl/load.py
@@ -1,0 +1,38 @@
+import logging
+from pathlib import Path
+import pandas as pd
+
+#Define output directory for curated data
+app_path = Path(__file__).parent
+output_dir = app_path.parent / "data" / "curated"
+
+def load_to_curated_folder(flat_table, file_tag, output_dir=output_dir):
+    """
+    Load the transformed data into a curated folder.
+    
+    :param flat_table: The DataFrame containing the transformed data.
+    :param output_dir: The directory where the curated data will be saved.
+    :param file_tag: A tag to identify the file, typically based on the date.
+    """
+    curated_file_path = output_dir / f"curated_data_{file_tag}.csv"
+    flat_table.to_csv(curated_file_path, index=False)
+    logging.info(f"Curated data saved to {curated_file_path}")
+
+def load_to_aws_bucket(flat_table, bucket_name, file_tag):
+    """
+    Load the transformed data into an AWS S3 bucket.
+    
+    :param flat_table: The DataFrame containing the transformed data.
+    :param bucket_name: The name of the S3 bucket.
+    :param file_tag: A tag to identify the file, typically based on the date.
+    """
+    import boto3
+    from io import StringIO
+    
+    s3 = boto3.client('s3')
+    csv_buffer = StringIO()
+    flat_table.to_csv(csv_buffer, index=False)
+
+    logging.info(f"Uploading curated data to S3 bucket {bucket_name} with key curated_data_{file_tag}.csv")
+    s3.put_object(Bucket=bucket_name, Key=f"curated_data_{file_tag}.csv", Body=csv_buffer.getvalue())
+    logging.info(f"Curated data uploaded to S3 bucket {bucket_name} with key curated_data_{file_tag}.csv")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,7 @@
+pandas
 requests
+boto3
+python-dotenv
+pyarrow
+s3fs
+


### PR DESCRIPTION
This PR implements the final "load" phase of the ETL pipeline.

Key changes include:
- A new `etl/load.py` module is created.
- Adds a function to save the transformed DataFrame as a csv file to the local `data/curated` folder.
- Adds a function to upload the final csv file to the configured S3 bucket.
- Integrates this step into `main.py`, which can be run with `python main.py --step load`.